### PR TITLE
Install doxygen at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     - curl http://download.opensuse.org/repositories/YaST:/Head:/Travis/xUbuntu_12.04/Release.key | sudo apt-key add -
     - echo "deb http://download.opensuse.org/repositories/YaST:/Head:/Travis/xUbuntu_12.04/ ./" | sudo tee -a /etc/apt/sources.list
     - sudo apt-get update -q
-    - sudo apt-get install --no-install-recommends -y yast2-core-dev yast2-devtools yast2-testsuite libcurl4-openssl-dev
+    - sudo apt-get install --no-install-recommends -y yast2-core-dev yast2-devtools yast2-testsuite libcurl4-openssl-dev doxygen
 script:
     - make -f Makefile.cvs
     - make


### PR DESCRIPTION
Fixed build failure caused by missing `doxygen`.
