### PR TITLE
Drop yast2-transfer-devel-doc package

### DIFF
--- a/agent-curl/Makefile.am
+++ b/agent-curl/Makefile.am
@@ -2,5 +2,5 @@
 # Makefile.am for .../agent-XXpkgXX/doc
 #
 
-SUBDIRS = doc src conf
+SUBDIRS = src conf
 

--- a/agent-curl/doc/.gitignore
+++ b/agent-curl/doc/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/agent-curl/doc/Makefile.am
+++ b/agent-curl/doc/Makefile.am
@@ -1,6 +1,0 @@
-#
-# Makefile.am for .../agent-XXpkgXX/doc
-#
-
-SUBDIRS = autodocs
-

--- a/agent-curl/doc/autodocs/.gitignore
+++ b/agent-curl/doc/autodocs/.gitignore
@@ -1,9 +1,0 @@
-Makefile
-Makefile.in
-*.html
-*.png
-*.tag
-doxygen.css
-doxygen.log
-doxygen.conf
-installdox

--- a/agent-curl/doc/autodocs/Makefile.am
+++ b/agent-curl/doc/autodocs/Makefile.am
@@ -1,6 +1,0 @@
-#
-# Makefile.am for .../agent-curl/doc/autodocs
-#
-
-AUTODOCS_SUBDIR=agent-curl
-include $(top_srcdir)/autodocs-cc.ami

--- a/agent-tftp/Makefile.am
+++ b/agent-tftp/Makefile.am
@@ -2,5 +2,5 @@
 # Makefile.am for .../agent-XXpkgXX/doc
 #
 
-SUBDIRS = doc src conf
+SUBDIRS = src conf
 

--- a/agent-tftp/doc/.gitignore
+++ b/agent-tftp/doc/.gitignore
@@ -1,2 +1,0 @@
-Makefile.in
-Makefile

--- a/agent-tftp/doc/Makefile.am
+++ b/agent-tftp/doc/Makefile.am
@@ -1,6 +1,0 @@
-#
-# Makefile.am for .../agent-XXpkgXX/doc
-#
-
-SUBDIRS = autodocs
-

--- a/agent-tftp/doc/autodocs/.gitignore
+++ b/agent-tftp/doc/autodocs/.gitignore
@@ -1,9 +1,0 @@
-Makefile.in
-Makefile
-*.html
-*.png
-*.tag
-doxygen.css
-doxygen.log
-doxygen.conf
-installdox

--- a/agent-tftp/doc/autodocs/Makefile.am
+++ b/agent-tftp/doc/autodocs/Makefile.am
@@ -1,6 +1,0 @@
-#
-# Makefile.am for .../agent-tftp/doc/autodocs
-#
-
-AUTODOCS_SUBDIR=agent-tftp
-include $(top_srcdir)/autodocs-cc.ami

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,9 +1,0 @@
-#
-# Makefile.am for devtools/devtools/skeletons/agent/doc
-#
-
-
-htmldir = $(docdir)
-
-html_DATA = curl.html tftp.html
-EXTRA_DIST = $(html_DATA)

--- a/package/yast2-transfer.changes
+++ b/package/yast2-transfer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  2 08:58:27 UTC 2016 - igonzalezsosa@suse.com
+
+- Drop yast2-transfer-devel-doc package (fate#320356)
+- 3.1.3
+
+-------------------------------------------------------------------
 Mon Jan 26 13:56:18 UTC 2015 - jreidinger@suse.com
 
 - fixed \r character lost during conversion to Ruby (bnc#344123)

--- a/package/yast2-transfer.spec
+++ b/package/yast2-transfer.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-transfer
-Version:        3.1.2
+Version:        3.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -39,15 +39,6 @@ Requires:	curl
 
 %description
 A YaST2 Agent for various Transfer Protocols: FTP, HTTP, and TFTP.
-
-%package devel-doc
-Requires:       yast2-transfer = %version
-Group:          System/YaST
-Summary:        YaST2 - Transfer - Development Documentation
-
-%description devel-doc
-This package contains development documentation for using the API
-provided by yast2-transfer package.
 
 %prep
 %setup -n %{name}-%{version}
@@ -73,9 +64,3 @@ rm -f $RPM_BUILD_ROOT/%{yast_plugindir}/libpy2ag_tftp.la
 
 %dir %{yast_docdir}
 %doc %{yast_docdir}/COPYING
-
-%files devel-doc
-%doc %{yast_docdir}/*.html
-%doc %{yast_docdir}/agent-curl
-%doc %{yast_docdir}/agent-tftp
-


### PR DESCRIPTION
Drop yast2-transfer-devel-doc package ([fate#320356](https://fate.suse.com/320356)).