### PR TITLE
Fixed TFTP download (bsc#1208754)

### DIFF
--- a/agent-tftp/src/TftpAgent.cc
+++ b/agent-tftp/src/TftpAgent.cc
@@ -333,7 +333,7 @@ int dotftp(char *serverstr, char *localfile, char *action)
 	
     if (strncmp(action, "get", 3) == 0) {
 	cmd = tftp_cmd_get; 
-	flags = O_WRONLY | O_CREAT;
+	flags = O_WRONLY | O_CREAT | O_TRUNC;
 	y2debug("Getting file...");
     } else if (strncmp(action, "put", 3) == 0){
 	cmd = tftp_cmd_put; 

--- a/package/yast2-transfer.changes
+++ b/package/yast2-transfer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Mar  1 07:54:03 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed TFTP download, truncate the target file to avoid garbage
+  at the end of the file when saving to an already existing file
+  (bsc#1208754)
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue Apr 20 18:14:05 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop packaging docdir, it only contained the license which

--- a/package/yast2-transfer.spec
+++ b/package/yast2-transfer.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-transfer
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Agent for Various Transfer Protocols
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1208754
- When downloading an AutoYaST profile from a TFTP server YaST displays a validation error. The problem is that the downloaded file contains some garbage data at the end which make the file invalid.

## Details

- AutoYaST during its run reuses the same temporary file for several steps, so when downloading the profile from TFTP there already might be some content in the target file.
- The TFPT agent did not remove the old data and if the downloaded content was shorter than the already present data the old content at the end was kept.

*Note: It's a bit strange that AutoYaST downloads the same file several times, but that a different problem and the download operation must be idempotent anyway...*

## Solution

- Use `O_TRUNC` flag so the existing file is truncated to size 0, the previous content of the file is deleted.

